### PR TITLE
Don't compile with native flag

### DIFF
--- a/src/bear.erl
+++ b/src/bear.erl
@@ -39,7 +39,6 @@
 -record(scan_result, {n=0, sumX=0, sumXX=0, sumInv=0, sumLog, max, min}).
 -record(scan_result2, {x2=0, x3=0, x4=0}).
 
--compile([native]).
 
 get_statistics([_,_,_,_,_|_] = Values) ->
     Scan_res = scan_values(Values),


### PR DESCRIPTION
Since bear [declares a flag](https://github.com/boundary/bear/blob/88ff370b8d859d390b20f62d797bfc03369851fd/src/bear.erl#L42) to compile with HiPE support, it's surprise that it doesn't works:

```
$ ./rebar eunit
==> bear (eunit)
Compiled test/bear_test.erl
Compiled src/bear.erl
...
bear_test: negative2_test...*failed*
in function bear:get_statistics_subset/2
  called as get_statistics_subset([-1,-1,-2,-2,-3,-5,-6,-10],[min])
in call from bear_test:negative2_test/0 (test/bear_test.erl, line 284)
in call from bear_test:negative2_test/0
**error:undef



=ERROR REPORT==== 7-May-2015::14:36:54 ===
Native loading of /home/kxepal/projects/forks/bear/.eunit/bear.beam failed: {'EXIT',
                                                                             {badarg,
                                                                              [{hipe_bifs,
                                                                                patch_call,
                                                                                [1079926198,
                                                                                 140635773809724,
                                                                                 []],
                                                                                []},
                                                                               {hipe_unified_loader,
                                                                                patch_call_insn,
                                                                                3,
                                                                                [{file,
                                                                                  "hipe_unified_loader.erl"},
                                                                                 {line,
                                                                                  507}]},
                                                                               {hipe_unified_loader,
                                                                                patch_bif_call_list,
                                                                                4,
                                                                                [{file,
                                                                                  "hipe_unified_loader.erl"},
                                                                                 {line,
                                                                                  492}]},
                                                                               {hipe_unified_loader,
                                                                                patch_call,
                                                                                5,
                                                                                [{file,
                                                                                  "hipe_unified_loader.erl"},
                                                                                 {line,
                                                                                  483}]},
                                                                               {hipe_unified_loader,
                                                                                patch,
                                                                                5,
                                                                                [{file,
                                                                                  "hipe_unified_loader.erl"},
                                                                                 {line,
                                                                                  458}]},
                                                                               {hipe_unified_loader,
                                                                                load_common,
                                                                                4,
                                                                                [{file,
                                                                                  "hipe_unified_loader.erl"},
                                                                                 {line,
                                                                                  235}]},
                                                                               {hipe_unified_loader,
                                                                                load_native_code,
                                                                                2,
                                                                                [{file,
                                                                                  "hipe_unified_loader.erl"},
                                                                                 {line,
                                                                                  105}]},
                                                                               {code_server,
                                                                                load_native_code,
                                                                                2,
                                                                                [{file,
                                                                                  "code_server.erl"},
                                                                                 {line,
                                                                                  1294}]}]}}
undefined
*** test module not found ***
**bear

=======================================================
  Failed: 46.  Skipped: 0.  Passed: 1.
One or more tests were cancelled.
ERROR: Cover analyze failed for bear: {not_cover_compiled,bear} "/home/kxepal/projects/forks/bear/.eunit/bear.beam"
ERROR: eunit failed while processing /home/kxepal/projects/forks/bear: {'EXIT',
    {function_clause,
        [{rebar_eunit,'-cover_write_index/2-fun-0-',[{0,0},[bear]],[]},
         {lists,partition,4,[{file,"lists.erl"},{line,1300}]},
         {rebar_eunit,cover_write_index,2,[]},
         {rebar_eunit,cover_analyze,3,[]},
         {rebar_eunit,eunit,2,[]},
         {rebar_core,run_modules,4,[]},
         {rebar_core,execute,4,[]},
         {rebar_core,process_dir,4,[]}]}}

```

Reproduced with 17.5 and 18.1 releases. R16B03-1 work fine with HiPE however.

Old references:
https://github.com/boundary/bear/issues/22
https://github.com/boundary/bear/pull/23
