### PR TITLE
Add hex metadata

### DIFF
--- a/src/bear.app.src
+++ b/src/bear.app.src
@@ -1,9 +1,12 @@
 {application, bear,
  [
   {description, "A set of statistics functions for erlang"},
-  {vsn, git},
+  {vsn, "0.8.3"}, %% replace as appropriate after tagging repo
   {registered, []},
   {applications, []},
   {env, []},
-  {modules, []}
+  {modules, []},
+  {maintainers, ["Joe Williams"]},
+  {licenses, ["Apache 2"]},
+  {links, [{"Github", "https://github.com/project-folsom/bear"}]}
  ]}.


### PR DESCRIPTION
Adds hex publishing metadata to the repo. The comment can (should?) be removed after a new tag is pushed and published.