### PR TITLE
fix app.src to satisfy rebar3 lint

### DIFF
--- a/src/bear.app.src
+++ b/src/bear.app.src
@@ -3,7 +3,8 @@
   {description, "A set of statistics functions for erlang"},
   {vsn, "0.8.7"}, %% replace as appropriate after tagging repo
   {registered, []},
-  {applications, []},
+  {applications, [kernel,
+                  stdlib]},
   {env, []},
   {modules, []},
   {maintainers, ["Joe Williams"]},


### PR DESCRIPTION
rebar3 now complains if kernel or stdlib is missing from app.src files.