### PR TITLE
Fix type of histogram in statistics.

### DIFF
--- a/src/bear.erl
+++ b/src/bear.erl
@@ -121,6 +121,8 @@ get_statistics_subset(Values, Items) when is_list(Values) ->
 
 get_null_statistics_subset([{percentile, Ps}|Items], Acc) ->
     get_null_statistics_subset(Items, [{percentile, [{P, 0.0} || P <- Ps]}|Acc]);
+get_null_statistics_subset([histogram|Items], Acc) ->
+    get_null_statistics_subset(Items, [{histogram, [{0, 0}]}|Acc]);
 get_null_statistics_subset([I|Items], Acc) ->
     get_null_statistics_subset(Items, [{I, 0.0}|Acc]);
 get_null_statistics_subset([], Acc) ->

--- a/test/bear_test.erl
+++ b/test/bear_test.erl
@@ -265,6 +265,12 @@ get_statistics_subset_regular_test() ->
     %% Regular case
     ?assertEqual([{max, 50},{min, -49}], bear:get_statistics_subset(sample1(), [max,min])).
 
+get_statistics_subset_empty_test() ->
+    Percentile = [{50, 0.0}, {75, 0.0}, {95, 0.0}, {99, 0.0}, {999, 0.0}],
+    ?assertEqual([{percentile, Percentile}], bear:get_statistics_subset([], [{percentile, [50, 75, 95, 99, 999]}])),
+    ?assertEqual([{histogram, [{0, 0}]}], bear:get_statistics_subset([], [histogram])),
+    ?assertEqual([{max, 0.0}, {min, 0.0}], bear:get_statistics_subset([], [max, min])).
+
 subset_test() ->
     Stats = bear:get_statistics(test_values()),
     match_values(Stats).


### PR DESCRIPTION
Type of histogram in statistics changes to number() or list() by the call arguments of `get_statistics_subset`.

I use folsom and bear in combination.
```
1> application:start(bear).
ok
2> folsom:start().
ok
3> folsom_metrics:new_histogram(h).
ok
4> folsom_metrics:get_histogram_statistics(h).
[{arithmetic_mean,0.0},
 {geometric_mean,0.0},
 {harmonic_mean,0.0},
 {histogram,0.0},         <---------- number()
 {kurtosis,0.0},
 {n,0.0},
 {max,0.0},
 {median,0.0},
 {min,0.0},
 {percentile,[{50,0.0},{75,0.0},{95,0.0},{99,0.0},{999,0.0}]},
 {skewness,0.0},
 {standard_deviation,0.0},
 {variance,0.0}]
5> folsom_metrics:notify(h, 1).
ok
6> folsom_metrics:notify(h, 1).
ok
7> folsom_metrics:notify(h, 1).
ok
8> folsom_metrics:notify(h, 1).
ok
9> folsom_metrics:notify(h, 1).
ok
10> folsom_metrics:get_histogram_statistics(h).
[{arithmetic_mean,1.0},
 {geometric_mean,1.0},
 {harmonic_mean,1.0},
 {histogram,[{1,5}]},     <---------- list()
 {kurtosis,0.0},
 {n,5},
 {max,1},
 {median,1},
 {min,1},
 {percentile,[{50,1},{75,1},{95,1},{99,1},{999,1}]},
 {skewness,0.0},
 {standard_deviation,0.0},
 {variance,0.0}]
```