### PR TITLE
Fix eunit

### DIFF
--- a/src/bear.erl
+++ b/src/bear.erl
@@ -42,6 +42,37 @@
          tied_rank_worker/3
         ]).
 
+-ifdef(TEST).
+-export([ arithmetic_mean/1
+        , geometric_mean/1
+        , get_bin_count/3
+        , get_bin_width/2
+        , get_covariance/2
+        , get_hist_bins/4
+        , get_kendall_correlation/2
+        , get_pearson_correlation/2
+        , get_spearman_correlation/2
+        , harmonic_mean/1
+        , inverse/1
+        , kurtosis/2
+        , math_log/1
+        , perc/2
+        , percentile/3
+        , ranks_of/1
+        , revsort/1
+        , round_bin/1
+        , round_bin/2
+        , scan_values/1
+        , scan_values/2
+        , scan_values2/2
+        , scan_values2/3
+        , skewness/2
+        , std_deviation/2
+        , update_bin/3
+        , variance/2
+        ]).
+-endif.
+
 -define(HIST_BINS, 10).
 
 -define(STATS_MIN, 5).

--- a/test/bear_test.erl
+++ b/test/bear_test.erl
@@ -23,6 +23,7 @@
 %%% ====================================================================
 -module(bear_test).
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -record(scan_result, {n=0, sumX=0, sumXX=0, sumInv=0, sumLog, max, min}).


### PR DESCRIPTION
Attempting to `rebar3 do compile,eunit` in `bear` fails with

```
Verifying dependencies...
Analyzing applications...
Compiling bear
Verifying dependencies...
Analyzing applications...
Compiling bear
test/bear_test.erl:26: Warning: export_all flag enabled - all functions will be exported

Performing EUnit tests...
......FFFFFFFFFFFFFFFFFFFFFFF.FFFFF....F........
Failures:

  1) bear_test:scan_values_test/0
     Failure/Error: {error,undef,
                        [{bear,scan_values,
                             [[],
                              {scan_result,8,0,0,0,undefined,undefined,
                                  undefined}],
                             []},
                         {bear_test,'-scan_values_test/0-fun-0-',0,
                             [{file,"/tmp/bear.git/test/bear_test.erl"},
                              {line,109}]},
                         {bear_test,scan_values_test,0,
                             [{file,"/tmp/bear.git/test/bear_test.erl"},
                              {line,109}]},
                         {bear_test,scan_values_test,0,[]}]}
     Output: 
```
(many more, pointing to various functions)
```

Finished in 0.157 seconds
48 tests, 29 failures
Error running tests
```
The issue is that the eunit tests call non-exported (non-API) functions in `bear.erl`. That worked long ago when `bear.erl` had an `export_all`, but that was removed.
I didn't want to add back the `export_all` so I opted to export the needed functions within an `-ifdef(TEST)` block.

The second commit just silences the warning one gets from the `export_all` in `bear_test.erl`.

With these I get clean `eunit` runs in `bear`.
