### PR TITLE
rebar.config: disable export_not_used xref check

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,7 @@
 {deps, []}.
 {erl_opts, [debug_info]}.
 {cover_enabled, true}.
+
+%% xref - default checks except export_not_used, which is pointless here
+{xref_checks, [undefined_function_calls,undefined_functions,locals_not_used,
+               deprecated_function_calls,deprecated_functions]}.


### PR DESCRIPTION
Running `rebar3 do compile,xref` in `bear` throws a bunch of warnings:

```
Verifying dependencies...
Analyzing applications...
Compiling bear
Verifying dependencies...
Analyzing applications...
Compiling bear
Running cross reference analysis...
src/bear.erl:53: Warning: bear:get_statistics/1 is unused export (Xref)
src/bear.erl:168: Warning: bear:get_statistics/2 is unused export (Xref)
src/bear.erl:108: Warning: bear:get_statistics_subset/2 is unused export (Xref)
src/bear.erl:492: Warning: bear:kendall_right_of/2 is unused export (Xref)
src/bear.erl:497: Warning: bear:kendall_right_of_item/2 is unused export (Xref)
src/bear.erl:475: Warning: bear:simple_ranking/1 is unused export (Xref)
src/bear.erl:500: Warning: bear:tied_add_prev/2 is unused export (Xref)
src/bear.erl:481: Warning: bear:tied_ordered_ranking/1 is unused export (Xref)
src/bear.erl:484: Warning: bear:tied_ordered_ranking/3 is unused export (Xref)
src/bear.erl:503: Warning: bear:tied_rank_worker/3 is unused export (Xref)
src/bear.erl:478: Warning: bear:tied_ranking/1 is unused export (Xref)
```
Since `bear` is a single-module library application it's expected that  there are no calls to its API functions.

I fixed that by adding `xref_checks` to `rebar.config` with the default checks (as per rebar3 documentation) _except_ for `export_not_used` which is the problematic one here. (Alternatively one can add a list of exceptions, but that gets ugly.)

With this I get clean `xref` runs in `bear`.