### PR TITLE
bear: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/bear.erl
+++ b/src/bear.erl
@@ -250,8 +250,7 @@ arithmetic_mean(#scan_result{n=N, sumX=Sum}) ->
 geometric_mean(#scan_result{n=N, sumLog=SumLog}) ->
     math:exp(SumLog/N).
 
-harmonic_mean(#scan_result{sumInv=Zero}) when Zero =:= 0 orelse
-                                              Zero =:= 0.0 ->
+harmonic_mean(#scan_result{sumInv=Zero}) when Zero == 0 ->
     %% Protect against divide by 0 if we have all 0 values
     0;
 harmonic_mean(#scan_result{n=N, sumInv=Sum}) ->
@@ -280,7 +279,7 @@ std_deviation(Scan_res, Scan_res2) ->
 %% }
 skewness(#scan_result{n=N}=Scan_res, #scan_result2{x3=X3}=Scan_res2) ->
     case math:pow(std_deviation(Scan_res,Scan_res2), 3) of
-        0.0 ->
+        Num when Num == 0.0 ->
             0.0;  %% Is this really the correct thing to do here?
         Else ->
             (X3/N)/Else
@@ -296,7 +295,7 @@ skewness(#scan_result{n=N}=Scan_res, #scan_result2{x3=X3}=Scan_res2) ->
 %% }
 kurtosis(#scan_result{n=N}=Scan_res, #scan_result2{x4=X4}=Scan_res2) ->
     case math:pow(std_deviation(Scan_res,Scan_res2), 4) of
-        0.0 ->
+        Num when Num == 0.0 ->
             0.0;  %% Is this really the correct thing to do here?
         Else ->
             ((X4/N)/Else) - 3
@@ -398,7 +397,7 @@ get_pearson_correlation(Values1, Values2) ->
         end, {0,0,0,0,0,0}, Values1, Values2),
     Numer = (N*SumXY) - (SumX * SumY),
     case math:sqrt(((N*SumXX)-(SumX*SumX)) * ((N*SumYY)-(SumY*SumY))) of
-        0.0 ->
+        Denom when Denom == 0.0 ->
             0.0; %% Is this really the correct thing to do here?
         Denom ->
             Numer/Denom
@@ -416,7 +415,7 @@ foldl2(_F, Acc, [], []) ->
 %% wrapper for math:log/1 to avoid dividing by zero
 math_log(0) ->
     1;
-math_log(0.0) ->
+math_log(Num) when Num == 0.0 ->
     1.0;
 math_log(X) when X < 0 ->
     0; % it's not possible to take a log of a negative number, return 0
@@ -426,7 +425,7 @@ math_log(X) ->
 %% wrapper for calculating inverse to avoid dividing by zero
 inverse(0) ->
     0;
-inverse(0.0) ->
+inverse(Num) when Num == 0.0 ->
     0.0;
 inverse(X) ->
     1/X.

--- a/test/bear_test.erl
+++ b/test/bear_test.erl
@@ -128,6 +128,8 @@ geometric_mean_test() ->
 
 harmonic_mean_test() ->
     ?assertEqual(0, bear:harmonic_mean(#scan_result{n=100, sumInv=0})),
+    ?assertEqual(0, bear:harmonic_mean(#scan_result{n=100, sumInv=0.0})),
+    ?assertEqual(0, bear:harmonic_mean(#scan_result{n=100, sumInv=-0.0})),
     ?assertEqual(10.0, bear:harmonic_mean(#scan_result{n=100, sumInv=10})).
 
 percentile_test() ->
@@ -141,10 +143,18 @@ std_deviation_test() ->
     ?assertEqual(3.0, bear:std_deviation(#scan_result{n=10},#scan_result2{x2=81})).
 
 skewness_test() ->
+    %% check the handling of -0.0 and +0.0 from math:pow/2 in bear:skewness/2
+    ?assertEqual(0.0, bear:skewness(#scan_result{n=0},#scan_result2{x2=0.0})),
+    ?assertEqual(0.0, bear:skewness(#scan_result{n=2},#scan_result2{x2=0.0})),
+    %%
     ?assertEqual(0.0, bear:skewness(#scan_result{n=10},#scan_result2{x2=0,x3=81})),
     ?assertEqual(3.0, bear:skewness(#scan_result{n=10},#scan_result2{x2=81,x3=810})).
 
 kurtosis_test() ->
+    %% check the handling of -0.0 and +0.0 from math:pow/2 in bear:kurtosis/2
+    ?assertEqual(0.0, bear:skewness(#scan_result{n=0},#scan_result2{x2=0.0})),
+    ?assertEqual(0.0, bear:skewness(#scan_result{n=2},#scan_result2{x2=0.0})),
+    %%
     ?assertEqual(0.0, bear:kurtosis(#scan_result{n=10},#scan_result2{x2=0,x4=81})),
     ?assertEqual(-2.0, bear:kurtosis(#scan_result{n=10},#scan_result2{x2=81,x4=810})).
 
@@ -188,6 +198,11 @@ get_pearson_correlation_nullresult_test() ->
     B = [1,0.25,0,0.25,1],
     ?assertEqual(0.0, bear:get_pearson_correlation(A, B)).
 
+get_pearson_correlation_zeros_test() ->
+    %% check the handling of +0.0 from math:sqrt/1 in bear:get_pearson_correlation/2
+    Zeros = lists:duplicate(5, 0),
+    ?assertEqual(0.0, bear:get_pearson_correlation(Zeros, Zeros)).
+
 round_bin_test() ->
     ?assertEqual(10, bear:round_bin(10)),
     ?assertEqual(10, bear:round_bin(10, 5)),
@@ -228,11 +243,13 @@ get_spearman_correlation_regular_test()->
 math_log_test() ->
     ?assertEqual(1, bear:math_log(0)),
     ?assertEqual(1.0, bear:math_log(0.0)),
+    ?assertEqual(1.0, bear:math_log(-0.0)),
     ?assertEqual(true, approx(3.737669618283368, bear:math_log(42))).
 
 inverse_test() ->
     ?assertEqual(0, bear:inverse(0)),
     ?assertEqual(0.0, bear:inverse(0.0)),
+    ?assertEqual(0.0, bear:inverse(-0.0)),
     ?assertEqual(0.5, bear:inverse(2)).
 
 get_hist_bins_test() ->


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in bear results in:

===> Compiling bear
src/bear.erl:254:56: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/bear.erl:283:9: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/bear.erl:299:9: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/bear.erl:401:9: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/bear.erl:419:10: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/bear.erl:429:9: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from matches to numerical comparisons.